### PR TITLE
Fac - Week1 Day4: ViewModel 생성 및 데이터 분리 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,4 +44,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation "androidx.activity:activity-ktx:1.4.0"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Todolist">
         <activity
-            android:name=".main.MainActivity"
+            android:name="com.survivalcoding.todolist.presentation.main.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -19,8 +19,8 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".add.AddActivity"
-            android:exported="true"/>
+            android:name="com.survivalcoding.todolist.presentation.add.AddActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/survivalcoding/todolist/data/TodoRepository.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/data/TodoRepository.kt
@@ -3,13 +3,15 @@ package com.survivalcoding.todolist.data
 import com.survivalcoding.todolist.model.Todo
 import java.util.*
 
+// 데이터 관리 공간
 class TodoRepository {
     var todos = (1..30).map { num ->
         val today = Calendar.getInstance()
         today.add(Calendar.DATE, num)
         Todo(num.toLong(), "# $num", today.timeInMillis, "${num}번째 내용입니다")
-    }
+    } // todos 미리 정의
 
+    //todo를 업데이트 하는 방법
     fun updateTodos(todo: Todo){
         todos = todos.toMutableList().map { origin ->
             if (origin.id == todo.id) origin.copy(isDone = !origin.isDone)

--- a/app/src/main/java/com/survivalcoding/todolist/data/TodoRepository.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/data/TodoRepository.kt
@@ -4,7 +4,7 @@ import com.survivalcoding.todolist.model.Todo
 import java.util.*
 
 // 데이터 관리 공간
-class TodoRepository {
+object TodoRepository {
     var todos = (1..30).map { num ->
         val today = Calendar.getInstance()
         today.add(Calendar.DATE, num)
@@ -12,10 +12,22 @@ class TodoRepository {
     } // todos 미리 정의
 
     //todo를 업데이트 하는 방법
-    fun updateTodos(todo: Todo){
+    fun updateIsDone(todo: Todo){
         todos = todos.toMutableList().map { origin ->
             if (origin.id == todo.id) origin.copy(isDone = !origin.isDone)
             else origin
         }
+    }
+
+    fun updateTodo(todo: Todo){
+        todos = todos.toMutableList().map { origin ->
+            if (origin.id == todo.id) origin.copy(title = todo.title, date = todo.date, content = todo.content)
+            else origin
+        }
+    }
+
+    //todo를 업데이트 하는 방법
+    fun addTodo(todo: Todo){
+        todos = todos.plus(todo)
     }
 }

--- a/app/src/main/java/com/survivalcoding/todolist/data/TodoRepository.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/data/TodoRepository.kt
@@ -1,0 +1,19 @@
+package com.survivalcoding.todolist.data
+
+import com.survivalcoding.todolist.model.Todo
+import java.util.*
+
+class TodoRepository {
+    var todos = (1..30).map { num ->
+        val today = Calendar.getInstance()
+        today.add(Calendar.DATE, num)
+        Todo(num.toLong(), "# $num", today.timeInMillis, "${num}번째 내용입니다")
+    }
+
+    fun updateTodos(todo: Todo){
+        todos = todos.toMutableList().map { origin ->
+            if (origin.id == todo.id) origin.copy(isDone = !origin.isDone)
+            else origin
+        }
+    }
+}

--- a/app/src/main/java/com/survivalcoding/todolist/main/MainActivity.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/main/MainActivity.kt
@@ -4,15 +4,13 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.survivalcoding.todolist.add.AddActivity
-import com.survivalcoding.todolist.data.TodoRepository
 import com.survivalcoding.todolist.databinding.ActivityMainBinding
 import com.survivalcoding.todolist.main.adapter.TodoListAdapter
-import com.survivalcoding.todolist.model.Todo
-import java.util.*
-import kotlin.collections.ArrayList
+import com.survivalcoding.todolist.presentation.MainViewModel
 
 class MainActivity : AppCompatActivity() {
     /*
@@ -23,21 +21,23 @@ class MainActivity : AppCompatActivity() {
         ActivityMainBinding.inflate(layoutInflater)
     }
 
-    private val todoRepository = TodoRepository()
     private val adapter = TodoListAdapter()
-
+    private val mainViewModel: MainViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
         //ResultLauncher 정의
-        val resultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()){ result ->
-            if(result.resultCode == RESULT_OK){
-                val data = result.data
-                Toast.makeText(this, data!!.extras!!.getString("result"), Toast.LENGTH_SHORT).show()
+        val resultLauncher =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                if (result.resultCode == RESULT_OK) {
+                    val data = result.data
+                    Toast.makeText(this, data!!.extras!!.getString("result"), Toast.LENGTH_SHORT)
+                        .show()
+                }
             }
-        }
+
 
         val recyclerView = binding.todoRecyclerView
         recyclerView.adapter = adapter
@@ -46,31 +46,17 @@ class MainActivity : AppCompatActivity() {
 
         // ItemClickListener를 지정
         adapter.onItemClicked = { modify ->
-            todoRepository.updateTodos(modify)
-            adapter.submitList(todoRepository.todos)
+            mainViewModel.toggleTodo(modify)
+            adapter.submitList(mainViewModel.todos)
         }
 
-        adapter.submitList(todoRepository.todos)
+        adapter.submitList(mainViewModel.todos)
 
         //Add Button을 통해 다른 액티비티로 이동
         val addButton = binding.addButton
         addButton.setOnClickListener {
             val intent = Intent(this, AddActivity::class.java)
             resultLauncher.launch(intent)
-        }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putParcelableArrayList("todoList", ArrayList(todoRepository.todos))
-    }
-    // 호출 시점: onCreate 직후
-    // 이 방법의 경우 todos의 데이터를 다시 업데이트를 해야하는 문제를 안고 있음.
-    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
-        super.onRestoreInstanceState(savedInstanceState)
-        savedInstanceState.getParcelableArrayList<Todo>("todoList")?.let{
-            todoRepository.todos = it
-            adapter.submitList(todoRepository.todos)
         }
     }
 }

--- a/app/src/main/java/com/survivalcoding/todolist/main/MainActivity.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/main/MainActivity.kt
@@ -47,20 +47,22 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        val adapter = TodoListAdapter(todos)
+        val adapter = TodoListAdapter()
         val recyclerView = binding.todoRecyclerView
         recyclerView.adapter = adapter
         // RecyclerView에 layoutManager 지정으로 설정 가능
         recyclerView.layoutManager = LinearLayoutManager(this)
 
         // ItemClickListener를 지정
-        adapter.onItemClicked = { modify, position ->
+        adapter.onItemClicked = { modify ->
             todos = todos.toMutableList().map { origin ->
                 if (origin.id == modify.id) origin.copy(isDone = !origin.isDone)
                 else origin
             }
-            adapter.submitTodos(todos, position)
+            adapter.submitList(todos)
         }
+
+        adapter.submitList(todos)
 
         //Add Button을 통해 다른 액티비티로 이동
         val addButton = binding.addButton

--- a/app/src/main/java/com/survivalcoding/todolist/main/adapter/TodoDiffItemCallback.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/main/adapter/TodoDiffItemCallback.kt
@@ -1,0 +1,14 @@
+package com.survivalcoding.todolist.main.adapter
+
+import androidx.recyclerview.widget.DiffUtil
+import com.survivalcoding.todolist.model.Todo
+
+object TodoDiffItemCallback : DiffUtil.ItemCallback<Todo>() {
+    override fun areItemsTheSame(oldItem: Todo, newItem: Todo): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(oldItem: Todo, newItem: Todo): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/app/src/main/java/com/survivalcoding/todolist/main/adapter/TodoListAdapter.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/main/adapter/TodoListAdapter.kt
@@ -1,11 +1,8 @@
 package com.survivalcoding.todolist.main.adapter
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.BaseAdapter
 import androidx.recyclerview.widget.ListAdapter
-import androidx.recyclerview.widget.RecyclerView
 import com.survivalcoding.todolist.R
 import com.survivalcoding.todolist.model.Todo
 

--- a/app/src/main/java/com/survivalcoding/todolist/main/adapter/TodoListAdapter.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/main/adapter/TodoListAdapter.kt
@@ -4,12 +4,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.BaseAdapter
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.survivalcoding.todolist.R
 import com.survivalcoding.todolist.model.Todo
 
-class TodoListAdapter(private var items: List<Todo>) : RecyclerView.Adapter<TodoViewHolder>() {
-    var onItemClicked: (Todo, Int) -> Unit = { _: Todo, _: Int -> }
+class TodoListAdapter : ListAdapter<Todo, TodoViewHolder>(TodoDiffItemCallback) {
+    var onItemClicked: (Todo) -> Unit = { }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TodoViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_todo, parent, false)
@@ -17,13 +18,6 @@ class TodoListAdapter(private var items: List<Todo>) : RecyclerView.Adapter<Todo
     }
 
     override fun onBindViewHolder(holder: TodoViewHolder, position: Int) {
-        holder.bind(items[position])
-    }
-
-    override fun getItemCount(): Int = items.size
-
-    fun submitTodos(todos: List<Todo>, position: Int) {//todos를 교체한 후에 어댑터에 알려줌
-        items = todos
-        notifyItemChanged(position)
+        holder.bind(getItem(position))
     }
 }

--- a/app/src/main/java/com/survivalcoding/todolist/main/adapter/TodoViewHolder.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/main/adapter/TodoViewHolder.kt
@@ -1,11 +1,8 @@
 package com.survivalcoding.todolist.main.adapter
 
 import android.graphics.Color
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.survivalcoding.todolist.R
 import com.survivalcoding.todolist.databinding.ItemTodoBinding
 import com.survivalcoding.todolist.model.Todo
 import java.text.SimpleDateFormat

--- a/app/src/main/java/com/survivalcoding/todolist/main/adapter/TodoViewHolder.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/main/adapter/TodoViewHolder.kt
@@ -13,7 +13,7 @@ import java.util.*
 
 class TodoViewHolder(
     itemView: View,
-    val onItemClicked: (Todo, Int) -> Unit
+    val onItemClicked: (Todo) -> Unit
 ) : RecyclerView.ViewHolder(itemView) {
     private val binding = ItemTodoBinding.bind(itemView)
 
@@ -26,7 +26,7 @@ class TodoViewHolder(
         else binding.root.setBackgroundColor(Color.TRANSPARENT)
 
         itemView.setOnClickListener {
-            onItemClicked(todo, adapterPosition)
+            onItemClicked(todo)
         }
     }
 }

--- a/app/src/main/java/com/survivalcoding/todolist/model/Todo.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/model/Todo.kt
@@ -2,12 +2,13 @@ package com.survivalcoding.todolist.model
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import java.util.*
 
 @Parcelize
 data class Todo(
     val id: Long,
-    val title: String,
-    val date: Long,
-    val content: String,
+    val title: String = "",
+    val date: Long = Date().time,
+    val content: String = "",
     val isDone: Boolean = false
 ) : Parcelable

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/MainViewModel.kt
@@ -1,0 +1,21 @@
+package com.survivalcoding.todolist.presentation
+
+import androidx.lifecycle.ViewModel
+import com.survivalcoding.todolist.data.TodoRepository
+import com.survivalcoding.todolist.model.Todo
+
+// ViewModel: View로부터 독립적인 데이터 저장
+// Activity가 완전히 종료할 때까지 데이터를 계속 가지고 있음
+class MainViewModel : ViewModel() {
+    private val todoRepository = TodoRepository()
+
+    val todos get() = todoRepository.todos // todos 데이터 갱신
+
+    fun toggleTodo(todo: Todo) { // 하나만 업데이트
+        todoRepository.updateTodos(todo)
+    }
+
+    fun setTodos(todos: List<Todo>) { // 전체 업데이트
+        todoRepository.todos = todos
+    }
+}

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/add/AddActivity.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/add/AddActivity.kt
@@ -1,23 +1,79 @@
 package com.survivalcoding.todolist.presentation.add
 
+import android.app.DatePickerDialog
 import android.content.Intent
 import android.os.Bundle
+import android.widget.DatePicker
+import android.widget.Toast
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.survivalcoding.todolist.databinding.ActivityAddBinding
+import com.survivalcoding.todolist.presentation.main.MainViewModel
+import java.text.SimpleDateFormat
+import java.util.*
 
 class AddActivity : AppCompatActivity() {
-    private val binding : ActivityAddBinding by lazy{
+    private val binding: ActivityAddBinding by lazy {
         ActivityAddBinding.inflate(layoutInflater)
     }
+
+    private val addViewModel: AddViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
+        val title = binding.titleEditText
+        title.setText(addViewModel.todo.title)
+        val content = binding.contentEditText
+        content.setText(addViewModel.todo.content)
+        val calendar = binding.calendarText
+        calendar.text =
+            SimpleDateFormat("yy/MM/dd", Locale.getDefault()).format(addViewModel.todo.date)
+
+        //calendar 터치 이벤트 구현
+        val cal = Calendar.getInstance()
+        cal.timeInMillis = addViewModel.todo.date
+        calendar.setOnClickListener {
+            DatePickerDialog(
+                this,
+                { _, year, monthOfYear, dayOfMonth ->
+                    cal.set(Calendar.YEAR, year)
+                    cal.set(Calendar.MONTH, monthOfYear)
+                    cal.set(Calendar.DAY_OF_MONTH, dayOfMonth)
+                    addViewModel.setDate(cal.timeInMillis)
+                    calendar.text = SimpleDateFormat(
+                        "yy/MM/dd",
+                        Locale.getDefault()
+                    ).format(addViewModel.todo.date)
+                },
+                cal.get(Calendar.YEAR),
+                cal.get(Calendar.MONTH),
+                cal.get(Calendar.DAY_OF_MONTH)
+            ).show()
+        }
+
+        val addButton = binding.addButton
+        addButton.setOnClickListener {
+            if(title.text.isBlank()){
+                Toast.makeText(this, "제목을 입력하시오", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            addViewModel.updateTodo(
+                title.text.toString(),
+                addViewModel.todo.date,
+                content.text.toString()
+            )
+            val finIntent = Intent()
+            finIntent.putExtra("result", "성공")
+            setResult(RESULT_OK, finIntent)
+            finish()
+        }
+
         val exitButton = binding.exitButton
         exitButton.setOnClickListener {
             val finIntent = Intent()
-            finIntent.putExtra("result", "성공")
+            finIntent.putExtra("result", "돌아감")
             setResult(RESULT_OK, finIntent)
             finish()
         }

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/add/AddActivity.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/add/AddActivity.kt
@@ -1,4 +1,4 @@
-package com.survivalcoding.todolist.add
+package com.survivalcoding.todolist.presentation.add
 
 import android.content.Intent
 import android.os.Bundle

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/add/AddViewModel.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/add/AddViewModel.kt
@@ -1,0 +1,30 @@
+package com.survivalcoding.todolist.presentation.add
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.survivalcoding.todolist.data.TodoRepository
+import com.survivalcoding.todolist.model.Todo
+
+//SavedStateHandle 사용하면 액티비티에서 set할 필요 없이 바로 intent에서 값을 여기에 저장시킨다.
+class AddViewModel(handle: SavedStateHandle) : ViewModel() {
+    private val todoRepository = TodoRepository
+    var todo: Todo = Todo(id = (todoRepository.todos.size + 1).toLong())
+    private var isModifying = false
+
+    init{
+        handle.get<Int>("modify")?.let {
+            isModifying = true
+            todo = todoRepository.todos[it]
+        }
+    }
+
+    fun setDate(time: Long){
+        todo = todo.copy(date = time)
+    }
+
+    fun updateTodo(title: String, date: Long, content: String){
+        todo = todo.copy(title = title, date = date, content = content)
+        if(isModifying) todoRepository.updateTodo(todo)
+        else todoRepository.addTodo(todo)
+    }
+}

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/main/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.survivalcoding.todolist.main
+package com.survivalcoding.todolist.presentation.main
 
 import android.content.Intent
 import android.os.Bundle
@@ -7,10 +7,9 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.survivalcoding.todolist.add.AddActivity
+import com.survivalcoding.todolist.presentation.add.AddActivity
 import com.survivalcoding.todolist.databinding.ActivityMainBinding
-import com.survivalcoding.todolist.main.adapter.TodoListAdapter
-import com.survivalcoding.todolist.presentation.MainViewModel
+import com.survivalcoding.todolist.presentation.main.adapter.TodoListAdapter
 
 class MainActivity : AppCompatActivity() {
     /*

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/main/MainActivity.kt
@@ -34,6 +34,7 @@ class MainActivity : AppCompatActivity() {
                     val data = result.data
                     Toast.makeText(this, data!!.extras!!.getString("result"), Toast.LENGTH_SHORT)
                         .show()
+                    adapter.submitList(mainViewModel.todos)
                 }
             }
 
@@ -44,9 +45,15 @@ class MainActivity : AppCompatActivity() {
         recyclerView.layoutManager = LinearLayoutManager(this)
 
         // ItemClickListener를 지정
-        adapter.onItemClicked = { modify ->
+        adapter.onChangeIsDone = { modify ->
             mainViewModel.toggleTodo(modify)
             adapter.submitList(mainViewModel.todos)
+        }
+
+        adapter.onModifyTodo = {
+            val intent = Intent(this, AddActivity::class.java)
+            intent.putExtra("modify", it)
+            resultLauncher.launch(intent)
         }
 
         adapter.submitList(mainViewModel.todos)

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/main/MainViewModel.kt
@@ -1,4 +1,4 @@
-package com.survivalcoding.todolist.presentation
+package com.survivalcoding.todolist.presentation.main
 
 import androidx.lifecycle.ViewModel
 import com.survivalcoding.todolist.data.TodoRepository

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/main/MainViewModel.kt
@@ -7,12 +7,12 @@ import com.survivalcoding.todolist.model.Todo
 // ViewModel: View로부터 독립적인 데이터 저장
 // Activity가 완전히 종료할 때까지 데이터를 계속 가지고 있음
 class MainViewModel : ViewModel() {
-    private val todoRepository = TodoRepository()
+    private val todoRepository = TodoRepository
 
     val todos get() = todoRepository.todos // todos 데이터 갱신
 
     fun toggleTodo(todo: Todo) { // 하나만 업데이트
-        todoRepository.updateTodos(todo)
+        todoRepository.updateIsDone(todo)
     }
 
     fun setTodos(todos: List<Todo>) { // 전체 업데이트

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/main/adapter/TodoDiffItemCallback.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/main/adapter/TodoDiffItemCallback.kt
@@ -1,4 +1,4 @@
-package com.survivalcoding.todolist.main.adapter
+package com.survivalcoding.todolist.presentation.main.adapter
 
 import androidx.recyclerview.widget.DiffUtil
 import com.survivalcoding.todolist.model.Todo

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/main/adapter/TodoListAdapter.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/main/adapter/TodoListAdapter.kt
@@ -7,11 +7,12 @@ import com.survivalcoding.todolist.R
 import com.survivalcoding.todolist.model.Todo
 
 class TodoListAdapter : ListAdapter<Todo, TodoViewHolder>(TodoDiffItemCallback) {
-    var onItemClicked: (Todo) -> Unit = { }
+    var onChangeIsDone: (Todo) -> Unit = {}
+    var onModifyTodo: (Int) -> Unit = { }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TodoViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_todo, parent, false)
-        return TodoViewHolder(view, onItemClicked)
+        return TodoViewHolder(view, onChangeIsDone, onModifyTodo)
     }
 
     override fun onBindViewHolder(holder: TodoViewHolder, position: Int) {

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/main/adapter/TodoListAdapter.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/main/adapter/TodoListAdapter.kt
@@ -1,4 +1,4 @@
-package com.survivalcoding.todolist.main.adapter
+package com.survivalcoding.todolist.presentation.main.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/main/adapter/TodoViewHolder.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/main/adapter/TodoViewHolder.kt
@@ -1,4 +1,4 @@
-package com.survivalcoding.todolist.main.adapter
+package com.survivalcoding.todolist.presentation.main.adapter
 
 import android.graphics.Color
 import android.view.View

--- a/app/src/main/java/com/survivalcoding/todolist/presentation/main/adapter/TodoViewHolder.kt
+++ b/app/src/main/java/com/survivalcoding/todolist/presentation/main/adapter/TodoViewHolder.kt
@@ -10,7 +10,8 @@ import java.util.*
 
 class TodoViewHolder(
     itemView: View,
-    val onItemClicked: (Todo) -> Unit
+    val onChangeIsDone: (Todo) -> Unit,
+    val onModifyTodo: (Int) -> Unit,
 ) : RecyclerView.ViewHolder(itemView) {
     private val binding = ItemTodoBinding.bind(itemView)
 
@@ -18,12 +19,14 @@ class TodoViewHolder(
         binding.titleText.text = todo.title
         binding.timeText.text = SimpleDateFormat("yy/MM/dd", Locale.getDefault()).format(todo.date)
         binding.contentText.text = todo.content
+        binding.isDone.isChecked = todo.isDone
 
-        if (todo.isDone) binding.root.setBackgroundColor(Color.RED)
-        else binding.root.setBackgroundColor(Color.TRANSPARENT)
+        binding.isDone.setOnClickListener {
+            onChangeIsDone(todo)
+        }
 
         itemView.setOnClickListener {
-            onItemClicked(todo)
+            onModifyTodo(adapterPosition)
         }
     }
 }

--- a/app/src/main/res/drawable/ic_calendar.xml
+++ b/app/src/main/res/drawable/ic_calendar.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20,3h-1L19,1h-2v2L7,3L7,1L5,1v2L4,3c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,5c0,-1.1 -0.9,-2 -2,-2zM20,21L4,21L4,8h16v13z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_check.xml
+++ b/app/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_description.xml
+++ b/app/src/main/res/drawable/ic_description.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M14,2L6,2c-1.1,0 -1.99,0.9 -1.99,2L4,20c0,1.1 0.89,2 1.99,2L18,22c1.1,0 2,-0.9 2,-2L20,8l-6,-6zM16,18L8,18v-2h8v2zM16,14L8,14v-2h8v2zM13,9L13,3.5L18.5,9L13,9z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_stop.xml
+++ b/app/src/main/res/drawable/ic_stop.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/layout/activity_add.xml
+++ b/app/src/main/res/layout/activity_add.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -8,12 +9,84 @@
         android:id="@+id/exitButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="10dp"
-        android:layout_marginBottom="10dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="20dp"
         android:clickable="true"
         android:contentDescription="Go back"
+        android:focusable="true"
+        app:backgroundTint="#F44336"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:srcCompat="@android:drawable/ic_delete"
+        app:srcCompat="@drawable/ic_stop" />
+
+    <ImageView
+        android:id="@+id/calendarIcon"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="20dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/titleEditText"
+        app:srcCompat="@drawable/ic_calendar" />
+
+    <TextView
+        android:id="@+id/calendarText"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="@+id/calendarIcon"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/calendarIcon"
+        app:layout_constraintTop_toTopOf="@+id/calendarIcon"
+        tools:text="2022.01.01" />
+
+    <ImageView
+        android:id="@+id/descriptionIcon"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="20dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/calendarIcon"
+        app:srcCompat="@drawable/ic_description" />
+
+    <EditText
+        android:id="@+id/contentEditText"
+        android:layout_width="wrap_content"
+        android:layout_height="48dp"
+        android:layout_marginStart="10dp"
+        android:ems="10"
+        android:hint="Add Description"
+        android:inputType="textPersonName"
+        app:layout_constraintBottom_toBottomOf="@+id/descriptionIcon"
+        app:layout_constraintStart_toEndOf="@+id/descriptionIcon"
+        app:layout_constraintTop_toTopOf="@+id/descriptionIcon" />
+
+    <EditText
+        android:id="@+id/titleEditText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="20dp"
+        android:ems="10"
+        android:hint="Add Title"
+        android:inputType="textPersonName"
+        android:textSize="30sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/addButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="20dp"
+        android:contentDescription="Add Button"
+        android:clickable="true"
+        app:layout_constraintBottom_toTopOf="@+id/exitButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@drawable/ic_check"
         android:focusable="true" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".main.MainActivity">
+    tools:context=".presentation.main.MainActivity">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/todoRecyclerView"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,25 +6,38 @@
     android:layout_height="match_parent"
     tools:context=".presentation.main.MainActivity">
 
+    <TextView
+        android:id="@+id/mainTitleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="15dp"
+        android:text="To Do List"
+        android:textSize="30sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/todoRecyclerView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="15dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/mainTitleText" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/addButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="10dp"
-        android:layout_marginBottom="10dp"
         android:clickable="true"
         android:contentDescription="Add Data"
         android:focusable="true"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/mainTitleText"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/mainTitleText"
         app:srcCompat="@drawable/ic_add" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_todo.xml
+++ b/app/src/main/res/layout/item_todo.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools">
+    android:layout_margin="5dp">
 
     <TextView
         android:id="@+id/titleText"
@@ -13,9 +14,9 @@
         android:layout_marginTop="10dp"
         android:textSize="20sp"
         android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/isDone"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="title"/>
+        tools:text="title" />
 
     <TextView
         android:id="@+id/timeText"
@@ -25,17 +26,26 @@
         android:layout_marginEnd="10dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="time"/>
+        tools:text="time" />
 
     <TextView
         android:id="@+id/contentText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="10dp"
         android:layout_marginTop="10dp"
         android:layout_marginBottom="10dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/titleText"
         app:layout_constraintTop_toBottomOf="@+id/titleText"
-        tools:text="content"/>
+        tools:text="content" />
+
+    <CheckBox
+        android:id="@+id/isDone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:gravity="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION

- todoRepository를 통해 데이터 부분 분리
- MainViewModel을 통해 Activity가 데이터를 다루지 않고 뷰모델이 todoRepository 부분을 다룰 수 있게 처리
- ViewModel을 통해 onSaveInstanceState 사용하지 않아도 회전 후 데이터가 유지되게 수정
- 클린 아키텍쳐 형태에 맞춰서 패키지 생성 및 파일 이동 
- saveStateHandle을 통해 intent 내용을 바로 viewmodel에 넣을 수 있음

AddActivity에서 datepicker를 사용하기 위해 calendar 객체를 사용했는데 이것을 데이터로 분류해 todoRepository에 처리해야할지 아님 그냥 AddActivity에서 처리해도 되는지 궁금합니다.